### PR TITLE
feat: set up base page with navigation and upper bg

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,13 +1,18 @@
 <!DOCTYPE html>
 <html lang="en">
-  <head>
-    <meta charset="UTF-8" />
-    <link rel="icon" type="image/svg+xml" href="/vite.svg" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Vite + React + TS</title>
-  </head>
-  <body>
-    <div id="root"></div>
-    <script type="module" src="/src/main.tsx"></script>
-  </body>
+
+<head>
+  <meta charset="UTF-8" />
+  
+  <link rel="icon" type="image/svg+xml" href="/vite.svg" />
+
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Vite + React + TS</title>
+</head>
+
+<body>
+  <div id="root"></div>
+  <script type="module" src="/src/main.tsx"></script>
+</body>
+
 </html>

--- a/package.json
+++ b/package.json
@@ -11,7 +11,13 @@
   "dependencies": {
     "@emotion/react": "^11.10.5",
     "@emotion/styled": "^11.10.5",
+    "@fontsource/candal": "^4.5.9",
+    "@fontsource/lexend": "^4.5.15",
+    "@fontsource/permanent-marker": "^4.5.7",
+    "@fontsource/roboto": "^4.5.8",
+    "@mui/icons-material": "^5.11.0",
     "@mui/material": "^5.11.7",
+    "clsx": "^1.2.1",
     "localforage": "^1.10.0",
     "match-sorter": "^6.3.1",
     "react": "^18.2.0",
@@ -23,6 +29,8 @@
     "@types/react": "^18.0.27",
     "@types/react-dom": "^18.0.10",
     "@vitejs/plugin-react-swc": "^3.0.0",
+    "autoprefixer": "^10.4.13",
+    "postcss": "^8.4.21",
     "tailwindcss": "^3.2.4",
     "typescript": "^4.9.3",
     "vite": "^4.1.0"

--- a/postcss.config.cjs
+++ b/postcss.config.cjs
@@ -1,0 +1,6 @@
+module.exports = {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3,7 +3,13 @@ import { BrowserRouter as Router } from 'react-router-dom';
 import { blueGrey } from "@mui/material/colors";
 import React from "react";
 import { Routestrap } from "./Routestrap";
-
+import '@fontsource/roboto/300.css';
+import '@fontsource/roboto/400.css';
+import '@fontsource/roboto/500.css';
+import '@fontsource/roboto/700.css';
+import '@fontsource/candal';
+import '@fontsource/permanent-marker';
+import '@fontsource/lexend';
 
 const App = () => {
   const muiTheme = React.useMemo<Theme>(() => createTheme({

--- a/src/Routestrap.tsx
+++ b/src/Routestrap.tsx
@@ -1,11 +1,13 @@
 import { Route, Routes } from "react-router-dom";
+import { Page } from "./components/Page";
 
 export const Routestrap = () => (
   <Routes>
-    <Route path="" element={<></>}> // Page component
+    <Route path="" element={<Page />}> // Page component
       <Route index element={<></>} /> // Landing component
-      <Route path="/resume" element={<></>} /> // Resume component
+      <Route path="/about" element={<></>} /> // About Me component
       <Route path="/projects" element={<></>} /> // Projects component
+      <Route path="/resume" element={<></>} /> // Resume component
       <Route path="/contact" element={<></>} /> // Resume component
     </Route>
   </Routes>

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -1,6 +1,5 @@
 import { DarkMode, LightMode } from "@mui/icons-material";
-import { Box, Container, IconButton, Typography } from "@mui/material";
-import { grey } from "@mui/material/colors";
+import { Box, Container, IconButton } from "@mui/material";
 import clsx from "clsx";
 import { memo, useCallback } from "react";
 import { Link } from "react-router-dom";

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -1,0 +1,61 @@
+import { DarkMode, LightMode } from "@mui/icons-material";
+import { Box, Container, IconButton, Typography } from "@mui/material";
+import { grey } from "@mui/material/colors";
+import clsx from "clsx";
+import { memo, useCallback } from "react";
+import { Link } from "react-router-dom";
+
+const linkStyles = "no-underline block capitalize text-lg text-inherit font-medium transition-all duration-200 ease-in-out drop-shadow-sm hover:text-cyan-500";
+
+interface INavbar {
+  darkMode: boolean;
+  setDarkMode: React.Dispatch<React.SetStateAction<boolean>>;
+}
+
+export const Navbar = memo<INavbar>(({ darkMode, setDarkMode }) => {
+  const handleThemeChange = useCallback(() => {
+    setDarkMode(!darkMode);
+  }, [darkMode]);
+
+  return (
+    <Box className="flex items-center drop-shadow-md relative">
+      <Box className={clsx("absolute w-full h-full opacity-50 backdrop-blur-lg", darkMode ? 'bg-gray-900' : 'bg-white')} />
+      <Container className="flex items-center py-6">
+        <Box className="font-logo -rotate-6 -mt-7">
+          <Link to="/" replace className="group no-underline text-transparent">
+            <span className={clsx("fixed z-50 subpixel-antialiased tracking-tighter text-4xl font-logo", darkMode ? 'text-gray-200' : 'text-gray-900')}>
+              JOSHE
+            </span>
+            <span className={clsx(
+              "absolute subpixel-antialiased tracking-tighter text-4xl font-logo transition-all duration-300 ease-in-out translate-x-[1px] translate-y-[3px]",
+              "group-hover:translate-x-[3px] group-hover:translate-y-[5px] group-hover:opacity-95 group-hover:scale-105 opacity-40",
+              darkMode ? 'text-gray-300 group-hover:text-cyan-500' : 'text-gray-900 group-hover:text-cyan-400'
+            )}
+            >
+              JOSHE
+            </span>
+          </Link>
+        </Box>
+        <Box className={clsx("font-display tracking-tight flex space-x-4 ml-[150px]", darkMode ? 'text-gray-400' : 'text-gray-900')}>
+          <Link to="/resume" className={linkStyles}>
+            resume
+          </Link>
+          <Link to="/projects" className={linkStyles}>
+            projects
+          </Link>
+          <Link to="/contact" className={linkStyles}>
+            contact
+          </Link>
+          <Link to="/about" className={linkStyles}>
+            about
+          </Link>
+        </Box>
+        <IconButton onClick={handleThemeChange} className={clsx("ml-auto transition duration-100", darkMode ? 'text-gray-300' : 'text-gray-900')}>
+          {darkMode
+            ? <LightMode fontSize="large" className="text-inherit" />
+            : <DarkMode fontSize="large" className="text-inherit" />}
+        </IconButton>
+      </Container>
+    </Box>
+  )
+})

--- a/src/components/Page.tsx
+++ b/src/components/Page.tsx
@@ -1,5 +1,4 @@
 import { Box } from "@mui/material"
-import { lightBlue } from "@mui/material/colors"
 import { Container } from "@mui/system"
 import clsx from "clsx"
 import { useEffect, useState } from "react"

--- a/src/components/Page.tsx
+++ b/src/components/Page.tsx
@@ -1,0 +1,39 @@
+import { Box } from "@mui/material"
+import { lightBlue } from "@mui/material/colors"
+import { Container } from "@mui/system"
+import clsx from "clsx"
+import { useEffect, useState } from "react"
+import { Outlet } from "react-router-dom"
+import { Navbar } from "./Navbar"
+
+export const Page = () => {
+  const [darkMode, setDarkMode] = useState<boolean>(() => {
+    const storedDarkMode = localStorage.getItem('darkMode');
+    if (storedDarkMode) return storedDarkMode === 'true';
+    return false;
+  });
+
+  useEffect(() => {
+    localStorage.setItem('darkMode', `${darkMode}`);
+  }, [darkMode]);
+
+  return (
+    <Box className={clsx("w-screen h-screen", darkMode ? "bg-slate-800" : "bg-slate-100")}>
+      <Box className="absolute w-full z-0">
+        <Container className="relative h-[200px] w-[800px] opacity-50">
+          <div className="absolute top-0 -left-4 w-[520px] h-[420px] bg-cyan-300 rounded-full mix-blend-multiply blur-2xl opacity-70 animate-blob"></div>
+          <div className="absolute top-0 -right-4 w-[420px] h-96 bg-pink-300 rounded-full mix-blend-multiply blur-2xl opacity-70 animate-blob animation-delay-2000"></div>
+          <div className="absolute -bottom-8 left-1/4 w-96 h-[420px] bg-amber-300 rounded-full mix-blend-multiply blur-2xl opacity-70 animate-blob animation-delay-4000"></div>
+        </Container>
+      </Box>
+      <Box className="z-10 top-0">
+        <Navbar {...{darkMode, setDarkMode}} />
+      </Box>
+      <Container className="p-3 sm:p-6 lg:p-9">
+        <Box className="overflow-y-scroll overflow-x-hidden">
+          <Outlet />
+        </Box>
+      </Container>
+    </Box>
+  )
+}

--- a/src/index.css
+++ b/src/index.css
@@ -2,4 +2,13 @@
 @tailwind components;
 @tailwind utilities;
 
+@layer utilities {
+  .animation-delay-2000 {
+    animation-delay: 2s;
+  }
+  .animation-delay-4000 {
+    animation-delay: 4s;
+  }
+}
+
 ::-webkit-scrollbar {display:none;}

--- a/tailwind.config.cjs
+++ b/tailwind.config.cjs
@@ -5,7 +5,10 @@ module.exports = {
   corePlugins: {
     preflight: false
   },
-  content: ['./src/**/*.{html,js,ts,jsx,tsx}'],
+  content: [
+    './index.html',
+    './src/**/*.{html,js,ts,jsx,tsx}',
+  ],
   important: '#root',
   variants: {
     extend: {
@@ -20,8 +23,10 @@ module.exports = {
       },
       fontFamily: {
         display: ['Lexend', ...defaultTheme.fontFamily.sans],
-        logo: ['"Baloo 2"', 'cursive'],
-        base: ['"Inter"', 'sans-serif'],
+        logo: ['Permanent Marker'],
+      },
+      backgroundImage: {
+        'gradient-radial': 'radial-gradient(var(--tw-gradient-stops))',
       },
       colors: {
         accent: '#1C3A6B',
@@ -78,36 +83,51 @@ module.exports = {
         'gradient-y-fastest': 'gradient-y 2s ease infinite',
         'gradient-y-toofast': 'gradient-y 1s ease infinite',
         'gradient-xy': 'gradient-xy 15s ease infinite',
+        blob: 'blob 7s infinite',
         marquee: 'marquee linear infinite',
         marquee2: 'marquee2 linear infinite',
       },
       keyframes: {
+        blob: {
+          "0%": {
+            transform: "translate(0px, 0px) scale(1)",
+          },
+          "33%": {
+            transform: "translate(30px, -50px) scale(1.1)",
+          },
+          "66%": {
+            transform: "translate(-20px, 20px) scale(0.9)",
+          },
+          "100%": {
+            transform: "tranlate(0px, 0px) scale(1)",
+          },
+        },
         load: {
-          '0%': { 
+          '0%': {
             transform: 'rotate(0deg)',
             'border-radius': '44px',
-            
+
           },
-          '50%': { 
+          '50%': {
             transform: 'rotate(1080deg)',
             'border-radius': '30px'
           },
-          '100%': { 
+          '100%': {
             transform: 'rotate(0deg)',
             'border-radius': '44px'
           }
         },
         'load-inner': {
-          '0%': { 
+          '0%': {
             transform: 'rotate(180deg) scale(1)',
             'border-radius': '8px',
-            
+
           },
           '25%': {
             transform: 'rotate(90deg) scale(1.3)',
             'border-radius': '20px'
           },
-          '50%': { 
+          '50%': {
             transform: 'rotate(0deg) scale(1)',
             'border-radius': '12px'
           },
@@ -115,7 +135,7 @@ module.exports = {
             transform: 'rotate(90deg) scale(1.3)',
             'border-radius': '20px'
           },
-          '100%': { 
+          '100%': {
             transform: 'rotate(180deg) scale(1)',
             'border-radius': '8px'
           }
@@ -162,10 +182,10 @@ module.exports = {
     },
   },
   plugins: [
-    require('@tailwindcss/forms'), 
-    require('@tailwindcss/aspect-ratio'), 
-    require('@tailwindcss/typography'), 
-    require('@tailwindcss/line-clamp'),
-    require('tailwindcss-textshadow'),
+    // require('@tailwindcss/forms'), 
+    // require('@tailwindcss/aspect-ratio'), 
+    // require('@tailwindcss/typography'), 
+    // require('@tailwindcss/line-clamp'),
+    // require('tailwindcss-textshadow'),
   ],
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -281,6 +281,26 @@
   resolved "https://registry.yarnpkg.com/@esbuild/win32-x64/-/win32-x64-0.16.17.tgz#c5a1a4bfe1b57f0c3e61b29883525c6da3e5c091"
   integrity sha512-y+EHuSchhL7FjHgvQL/0fnnFmO4T1bhvWANX6gcnqTjtnKWbTvUMCpGnv2+t+31d7RzyEAYAd4u2fnIhHL6N/Q==
 
+"@fontsource/candal@^4.5.9":
+  version "4.5.9"
+  resolved "https://registry.yarnpkg.com/@fontsource/candal/-/candal-4.5.9.tgz#fd0d0057df356b2483d95a47a627ad6b7ad90fdd"
+  integrity sha512-udC1R41ebP0z1hd3WE8BUPtSsFEcqGYlTLvbbyWf005QtMao7RRUfFTQcH9FvsxFkhITCnsDOQDhhdfC72yxoQ==
+
+"@fontsource/lexend@^4.5.15":
+  version "4.5.15"
+  resolved "https://registry.yarnpkg.com/@fontsource/lexend/-/lexend-4.5.15.tgz#ee033b850224d05b665d6661bf8d32c950f166bb"
+  integrity sha512-6edLmDmte8pJWtQ1NIahcJq0iWlf6b0/JLwkd7WbDQ3C5tZWnxjvbP4RSklMv4MPzGjpuYuYnc+QANbjUws1oA==
+
+"@fontsource/permanent-marker@^4.5.7":
+  version "4.5.7"
+  resolved "https://registry.yarnpkg.com/@fontsource/permanent-marker/-/permanent-marker-4.5.7.tgz#e9c6c77c0210056acdf060b2785208b0dff17cda"
+  integrity sha512-1WFV2w9zBFaQ2BIH9xUq+9sRFs+uVg/QDLCSOOHrmIQPhAg0YHRoqCqAXxhHPnzqCp2Ai9d7ASRQZxbDhb6Itw==
+
+"@fontsource/roboto@^4.5.8":
+  version "4.5.8"
+  resolved "https://registry.yarnpkg.com/@fontsource/roboto/-/roboto-4.5.8.tgz#56347764786079838faf43f0eeda22dd7328437f"
+  integrity sha512-CnD7zLItIzt86q4Sj3kZUiLcBk1dSk81qcqgMGaZe7SQ1P8hFNxhMl5AZthK1zrDM5m74VVhaOpuMGIL4gagaA==
+
 "@mui/base@5.0.0-alpha.116":
   version "5.0.0-alpha.116"
   resolved "https://registry.yarnpkg.com/@mui/base/-/base-5.0.0-alpha.116.tgz#c167a66b7232088b4bcd97ba36096a357c6e4fb9"
@@ -299,6 +319,13 @@
   version "5.11.7"
   resolved "https://registry.yarnpkg.com/@mui/core-downloads-tracker/-/core-downloads-tracker-5.11.7.tgz#b3a3aad64c6b69f6165d7a00c0d9cfeacbe357a2"
   integrity sha512-lZgX7XQTk0zVcpwEa80r+T4y09dosnUxWvFPSikU/2Hh5wnyNOek8WfJwGCNsaRiXJHMi5eHY+z8oku4u5lgNw==
+
+"@mui/icons-material@^5.11.0":
+  version "5.11.0"
+  resolved "https://registry.yarnpkg.com/@mui/icons-material/-/icons-material-5.11.0.tgz#9ea6949278b2266d2683866069cd43009eaf6464"
+  integrity sha512-I2LaOKqO8a0xcLGtIozC9xoXjZAto5G5gh0FYUMAlbsIHNHIjn4Xrw9rvjY20vZonyiGrZNMAlAXYkY6JvhF6A==
+  dependencies:
+    "@babel/runtime" "^7.20.6"
 
 "@mui/material@^5.11.7":
   version "5.11.7"
@@ -555,6 +582,18 @@ arg@^5.0.2:
   resolved "https://registry.yarnpkg.com/arg/-/arg-5.0.2.tgz#c81433cc427c92c4dcf4865142dbca6f15acd59c"
   integrity sha512-PYjyFOLKQ9y57JvQ6QLo8dAgNqswh8M1RMJYdQduT6xbWSgK36P/Z/v+p888pM69jMMfS8Xd8F6I1kQ/I9HUGg==
 
+autoprefixer@^10.4.13:
+  version "10.4.13"
+  resolved "https://registry.yarnpkg.com/autoprefixer/-/autoprefixer-10.4.13.tgz#b5136b59930209a321e9fa3dca2e7c4d223e83a8"
+  integrity sha512-49vKpMqcZYsJjwotvt4+h/BCjJVnhGwcLpDt5xkcaOG3eLrG/HUYLagrihYsQ+qrIBgIzX1Rw7a6L8I/ZA1Atg==
+  dependencies:
+    browserslist "^4.21.4"
+    caniuse-lite "^1.0.30001426"
+    fraction.js "^4.2.0"
+    normalize-range "^0.1.2"
+    picocolors "^1.0.0"
+    postcss-value-parser "^4.2.0"
+
 babel-plugin-macros@^3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/babel-plugin-macros/-/babel-plugin-macros-3.1.0.tgz#9ef6dc74deb934b4db344dc973ee851d148c50c1"
@@ -576,6 +615,16 @@ braces@^3.0.2, braces@~3.0.2:
   dependencies:
     fill-range "^7.0.1"
 
+browserslist@^4.21.4:
+  version "4.21.5"
+  resolved "https://registry.yarnpkg.com/browserslist/-/browserslist-4.21.5.tgz#75c5dae60063ee641f977e00edd3cfb2fb7af6a7"
+  integrity sha512-tUkiguQGW7S3IhB7N+c2MV/HZPSCPAAiYBZXLsBhFB/PCy6ZKKsZrmBayHV9fdGV/ARIfJ14NkxKzRDjvp7L6w==
+  dependencies:
+    caniuse-lite "^1.0.30001449"
+    electron-to-chromium "^1.4.284"
+    node-releases "^2.0.8"
+    update-browserslist-db "^1.0.10"
+
 callsites@^3.0.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/callsites/-/callsites-3.1.0.tgz#b3630abd8943432f54b3f0519238e33cd7df2f73"
@@ -585,6 +634,11 @@ camelcase-css@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/camelcase-css/-/camelcase-css-2.0.1.tgz#ee978f6947914cc30c6b44741b6ed1df7f043fd5"
   integrity sha512-QOSvevhslijgYwRx6Rv7zKdMF8lbRmx+uQGx2+vDc+KI/eBnsy9kit5aj23AgGu3pa4t9AgwbnXWqS+iOY+2aA==
+
+caniuse-lite@^1.0.30001426, caniuse-lite@^1.0.30001449:
+  version "1.0.30001450"
+  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001450.tgz#022225b91200589196b814b51b1bbe45144cf74f"
+  integrity sha512-qMBmvmQmFXaSxexkjjfMvD5rnDL0+m+dUMZKoDYsGG8iZN29RuYh9eRoMvKsT6uMAWlyUUGDEQGJJYjzCIO9ew==
 
 chalk@^2.0.0:
   version "2.4.2"
@@ -690,6 +744,11 @@ dom-helpers@^5.0.1:
     "@babel/runtime" "^7.8.7"
     csstype "^3.0.2"
 
+electron-to-chromium@^1.4.284:
+  version "1.4.286"
+  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.4.286.tgz#0e039de59135f44ab9a8ec9025e53a9135eba11f"
+  integrity sha512-Vp3CVhmYpgf4iXNKAucoQUDcCrBQX3XLBtwgFqP9BUXuucgvAV9zWp1kYU7LL9j4++s9O+12cb3wMtN4SJy6UQ==
+
 error-ex@^1.3.1:
   version "1.3.2"
   resolved "https://registry.yarnpkg.com/error-ex/-/error-ex-1.3.2.tgz#b4ac40648107fdcdcfae242f428bea8a14d4f1bf"
@@ -724,6 +783,11 @@ esbuild@^0.16.14:
     "@esbuild/win32-arm64" "0.16.17"
     "@esbuild/win32-ia32" "0.16.17"
     "@esbuild/win32-x64" "0.16.17"
+
+escalade@^3.1.1:
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/escalade/-/escalade-3.1.1.tgz#d8cfdc7000965c5a0174b4a82eaa5c0552742e40"
+  integrity sha512-k0er2gUkLf8O0zKJiAhmkTnJlTvINGv7ygDNPbeIsX/TJjGJZHuh9B2UxbsaEkmlEo9MfhrSzmhIlhRlI2GXnw==
 
 escape-string-regexp@^1.0.5:
   version "1.0.5"
@@ -764,6 +828,11 @@ find-root@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/find-root/-/find-root-1.1.0.tgz#abcfc8ba76f708c42a97b3d685b7e9450bfb9ce4"
   integrity sha512-NKfW6bec6GfKc0SGx1e07QZY9PE99u0Bft/0rzSD5k3sO/vwkVUpDUKVm5Gpp5Ue3YfShPFTX2070tDs5kB9Ng==
+
+fraction.js@^4.2.0:
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/fraction.js/-/fraction.js-4.2.0.tgz#448e5109a313a3527f5a3ab2119ec4cf0e0e2950"
+  integrity sha512-MhLuK+2gUcnZe8ZHlaaINnQLl0xRIGRfcGk2yl8xoQAfHrSsL3rYu6FCmBdkdbhc9EPlwyGHewaRsvwRMJtAlA==
 
 fsevents@~2.3.2:
   version "2.3.2"
@@ -929,10 +998,20 @@ nanoid@^3.3.4:
   resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-3.3.4.tgz#730b67e3cd09e2deacf03c027c81c9d9dbc5e8ab"
   integrity sha512-MqBkQh/OHTS2egovRtLk45wEyNXwF+cokD+1YPf9u5VfJiRdAiRwB2froX5Co9Rh20xs4siNPm8naNotSD6RBw==
 
+node-releases@^2.0.8:
+  version "2.0.9"
+  resolved "https://registry.yarnpkg.com/node-releases/-/node-releases-2.0.9.tgz#fe66405285382b0c4ac6bcfbfbe7e8a510650b4d"
+  integrity sha512-2xfmOrRkGogbTK9R6Leda0DGiXeY3p2NJpy4+gNCffdUvV6mdEJnaDEic1i3Ec2djAo8jWYoJMR5PB0MSMpxUA==
+
 normalize-path@^3.0.0, normalize-path@~3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/normalize-path/-/normalize-path-3.0.0.tgz#0dcd69ff23a1c9b11fd0978316644a0388216a65"
   integrity sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==
+
+normalize-range@^0.1.2:
+  version "0.1.2"
+  resolved "https://registry.yarnpkg.com/normalize-range/-/normalize-range-0.1.2.tgz#2d10c06bdfd312ea9777695a4d28439456b75942"
+  integrity sha512-bdok/XvKII3nUpklnV6P2hxtMNrCboOjAcyBuQnWEhO665FwrSNRxU+AqpsyvO6LgGYPspN+lu5CLtw4jPRKNA==
 
 object-assign@^4.1.1:
   version "4.1.1"
@@ -1256,6 +1335,14 @@ typescript@^4.9.3:
   version "4.9.5"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.9.5.tgz#095979f9bcc0d09da324d58d03ce8f8374cbe65a"
   integrity sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==
+
+update-browserslist-db@^1.0.10:
+  version "1.0.10"
+  resolved "https://registry.yarnpkg.com/update-browserslist-db/-/update-browserslist-db-1.0.10.tgz#0f54b876545726f17d00cd9a2561e6dade943ff3"
+  integrity sha512-OztqDenkfFkbSG+tRxBeAnCVPckDBcvibKd35yDONx6OU8N7sqgwc7rCbkJ/WcYtVRZ4ba68d6byhC21GFh7sQ==
+  dependencies:
+    escalade "^3.1.1"
+    picocolors "^1.0.0"
 
 util-deprecate@^1.0.2:
   version "1.0.2"


### PR DESCRIPTION
This PR handles the following:

- Adds @fontsource deps for Lexend, Candal and Permanent Marker
- Creates Page component to house router outlet with main navigation and upper page bg
- Implements simple local storage dark mode theme control solution using Page as base provision

TODO: Move theme control into context to reduce prop drilling