### PR TITLE
feat: adding bottom alignment styles to the footer and cleaning up resume styling

### DIFF
--- a/personal.config.tsx
+++ b/personal.config.tsx
@@ -121,7 +121,7 @@ export const my: IMy = {
     {
       Icon: SettingsRounded,
       title: 'Full Stack Engineer',
-      company: 'Cognizant Technologies',
+      company: 'Cognizant',
       location: 'Plano, TX',
       duration: ['June 2021', 'Present'],
       bullets: [

--- a/src/components/ComingSoon.tsx
+++ b/src/components/ComingSoon.tsx
@@ -1,13 +1,16 @@
 import { Container } from "@mui/material";
 import clsx from "clsx";
+import { useEffect } from "react";
 import { useAppTheme } from "../lib/hooks/useAppTheme"
 
 export const ComingSoon = () => {
   const { darkMode } = useAppTheme();
 
+  useEffect(() => { document.title = "Joshe - Coming Soon!" }, []);
+
   return (
     <Container>
-      <h1 className={clsx("text-4xl sm:text-5xl font-display text-center mb-24", darkMode ? 'text-slate-200' : 'text-slate-800')}>Coming Soon!</h1>
+      <h1 className={clsx("text-4xl sm:text-5xl font-display text-center mb-24 animate-bounce", darkMode ? 'text-slate-200' : 'text-slate-800')}>Coming Soon!</h1>
     </Container>
   )
 }

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -43,7 +43,7 @@ export const Navbar = memo<INavbar>(({ theme, setDarkMode }) => {
   }, [theme.darkMode]);
 
   return (
-    <Box className="flex items-center drop-shadow-md z-20 fixed w-full top-0 backdrop-blur">
+    <Box className="flex items-center drop-shadow-md z-20 sticky w-full top-0 backdrop-blur">
       <Box className={clsx("absolute w-full h-full opacity-70 backdrop-blur-lg", theme.darkMode ? 'bg-slate-800' : 'bg-slate-100')} />
       <Container className="flex items-center py-3">
         <Box className="font-logo -rotate-6 -mt-[34px]">

--- a/src/components/Page.tsx
+++ b/src/components/Page.tsx
@@ -25,16 +25,16 @@ export const Page = () => {
   }, []);
 
   return (
-    <Box className={clsx("w-screen min-h-screen overflow-y-hidden", theme.darkMode ? "bg-slate-800" : "bg-slate-100")}>
-      <Navbar {...{ theme, setDarkMode }} />
+    <Box className={clsx("w-screen h-screen overflow-y-scroll relative flex flex-col", theme.darkMode ? "bg-slate-800" : "bg-slate-100")}>
       <Box className="absolute flex z-0 w-screen h-screen overflow-x-clip overflow-y-clip">
-        <Container className={clsx("relative h-[200px] w-[800px]", theme.darkMode ? 'opacity-40' : 'opacity-60')}>
+        <Container className={clsx("relative h-[200px] w-[800px]", theme.darkMode ? 'opacity-50' : 'opacity-80')}>
           <div className="absolute top-0 -left-4 w-[520px] h-[420px] bg-cyan-300 rounded-full mix-blend-multiply blur-2xl opacity-70 animate-blob" />
           <div className="absolute top-0 -right-4 w-[420px] h-96 bg-pink-300 rounded-full mix-blend-multiply blur-2xl opacity-70 animate-blob-slow animation-delay-2000" />
           <div className="absolute -bottom-8 left-1/4 w-96 h-[420px] bg-amber-300 rounded-full mix-blend-multiply blur-2xl opacity-70 animate-blob animation-delay-4000" />
         </Container>
       </Box>
-      <Box className="pt-40 relative z-10">
+      <Navbar {...{ theme, setDarkMode }} />
+      <Box className="pt-12 sm:pt-24 relative z-10 mb-auto">
         <Outlet context={theme} />
       </Box>
       <Divider className={clsx("w-screen my-12", theme.darkMode && "bg-slate-600")} />

--- a/src/components/Resume.tsx
+++ b/src/components/Resume.tsx
@@ -6,7 +6,7 @@ import { IMyExperience } from "../../personal.config";
 
 export const Header = (props: { darkMode: boolean }) => (
   <Box className='text-center pb-2'>
-    <h1 className={clsx("text-4xl font-bold font-display tracking-tight sm:text-5xl", props.darkMode ? 'text-slate-100' : 'text-slate-800')}>Joshua Shevach</h1>
+    <h1 className={clsx("text-4xl font-bold font-display tracking-tight sm:text-5xl mt-0", props.darkMode ? 'text-slate-100' : 'text-slate-800')}>Joshua Shevach</h1>
     <Box className={clsx("pb-2 [&>*]:inline-block [&>*]:px-4 [&>*]:pb-2", props.darkMode ? 'text-slate-300' : 'text-slate-600')}>
       <span>github.com/BentAllenDesign</span>
       <span>me@joshe.app</span>
@@ -30,8 +30,8 @@ interface IDetailProps {
 
 export const Details = memo<IMyExperience & IDetailProps>((props) => (
   <div className='flex flex-col pb-1 w-full'>
-    <span className={clsx("font-bold", props.size === 'lg' ? 'text-lg' : 'text-base')}>{props.title}</span>
-    <div className={clsx("flex justify-between whitespace-no-wrap flex-wrap", props.darkMode ? 'text-slate-400' : 'text-slate-600' )}>
+    <span className="font-bold text-lg">{props.title}</span>
+    <div className={clsx("flex justify-between whitespace-no-wrap flex-wrap", props.darkMode ? 'text-slate-400' : 'text-slate-600')}>
       <span>
         <i>{props.company}</i>
       </span>
@@ -46,18 +46,11 @@ export const Details = memo<IMyExperience & IDetailProps>((props) => (
   </div>
 ));
 
-export const HeartSeparatedList = (list: string[], darkMode: boolean) => {
-
-  return (
-    <span className="inline-flex flex-wrap gap-x-2 items-center first:hidden break-word">
-      {list.map((item, idx) => (
-        <>
-          <BoltRounded className="text-sm first:hidden" />
-          <span key={idx} className={clsx("w-max flex break-words", darkMode ? 'text-slate-300' : 'text-slate-700')}>
-            {item}
-          </span>
-        </>
-      ))}
+export const HeartSeparatedList = (list: string[], darkMode: boolean) => list.map((item, idx, arr) => (
+  <span className='inline-flex items-center'>
+    <span className={clsx("inline-flex", darkMode ? 'text-slate-300' : 'text-slate-700')}>
+      {item}
     </span>
-  );
-}
+    <BoltRounded className={clsx("text-sm mx-1", idx === arr.length - 1 && 'hidden')} />
+  </span>
+));

--- a/src/pages/LandingPage.tsx
+++ b/src/pages/LandingPage.tsx
@@ -15,52 +15,50 @@ export const LandingPage = (props: IPageProps) => {
 
   return (
     <>
-      <Container className="space-y-12">
-        <Box className="flex flex-col lg:flex-row gap-8 items-center justify-center">
-          <Box className="flex rounded-full overflow-clip h-44 w-44 min-w-36 drop-shadow lg:self-start items-center">
-            <img src="/headshot.jpg" alt="Joshua Shevach - headshot photo" className="object-cover h-48 w-56 self-center scale-150" />
-          </Box>
-          <Box className="max-w-2xl">
-            <h1 className={clsx("text-4xl font-bold font-display tracking-tight sm:text-5xl mt-0", darkMode ? 'text-slate-100' : 'text-slate-800')}>
-              Full-time software engineer.
-              <br />
-              Part-time travel pro.
-            </h1>
-            <p className={clsx("mt-6 text-base", darkMode ? 'text-slate-300' : 'text-slate-700')}>
-              I’m Josh, a full-stack software engineer and travel agent based in Frisco Texas. I’m the owner of
-              Cruisr LLC, a cruise travel agency I created to book cheaper cruises for my friends, family, and
-              colleagues! In my free time, I like to game, binge shows, and hone my engineering skills by building
-              bots and small full-stack apps.
-            </p>
-            <Box className="-ml-3 mt-5 flex sm:gap-2">
-              <IconButton
-                href="https://www.linkedin.com/in/joshua-shevach/"
-                aria-label="Follow on LinkedIn"
-                className={clsx("transition-all duration-100 ease-in-out", darkMode ? 'text-slate-400 hover:text-slate-200' : 'text-slate-800 hover:text-slate-600')}
-              >
-                <LinkedIn className="text-4xl sm:text-5xl" />
-              </IconButton>
-              <IconButton
-                href="https://github.com/BentAllenDesign"
-                aria-label="Follow on GitHub"
-                className={clsx("transition-all duration-100 ease-in-out", darkMode ? 'text-slate-400 hover:text-slate-200' : 'text-slate-800 hover:text-slate-600')}
-              >
-                <GitHub className="text-4xl sm:text-5xl" />
-              </IconButton>
-              <Button endIcon={<ChevronRightRounded />} className={clsx("ml-3 normal-case rounded-full font-bold text-base sm:text-lg sm:my-1 px-4 sm:px-6", darkMode ? 'bg-slate-400 hover:bg-slate-200 text-slate-800' : 'bg-slate-800 hover:bg-slate-600 text-slate-100')}>
-                <Link to="/about" className="text-inherit no-underline">
-                  Learn more about me!
-                </Link>
-              </Button>
-            </Box>
+      <Container className="flex flex-col lg:flex-row gap-8 items-center justify-center">
+        <Box className="flex rounded-full overflow-clip h-44 w-44 min-w-36 drop-shadow lg:self-start items-center">
+          <img src="/headshot.jpg" alt="Joshua Shevach - headshot photo" className="object-cover h-48 w-56 self-center scale-150" />
+        </Box>
+        <Box className="max-w-2xl">
+          <h1 className={clsx("text-3xl xs:text-4xl font-bold font-display tracking-tight sm:text-5xl mt-0", darkMode ? 'text-slate-100' : 'text-slate-800')}>
+            Full-time <span className="hidden xs:inline">software <span className="hidden sm:inline">engineer</span><span className="sm:hidden">dev</span></span><span className="xs:hidden">developer</span>.
+            <br />
+            Part-time travel pro.
+          </h1>
+          <p className={clsx("mt-6 text-base", darkMode ? 'text-slate-300' : 'text-slate-700')}>
+            I’m Josh, a full-stack software engineer for Cognizant in Frisco, Texas. I’m also the owner of
+            Cruisr LLC, a cruise travel agency I created to book cheaper cruises for my friends, family, and
+            colleagues! In my free time I like to play FPS or adventure games, binge sci-fi and anime shows,
+            and hone my engineering skills by building bots and small full-stack apps.
+          </p>
+          <Box className="-ml-3 mt-5 flex sm:gap-2">
+            <IconButton
+              href="https://www.linkedin.com/in/joshua-shevach/"
+              aria-label="Follow on LinkedIn"
+              className={clsx("transition-all duration-100 ease-in-out", darkMode ? 'text-slate-400 hover:text-slate-200' : 'text-slate-800 hover:text-slate-600')}
+            >
+              <LinkedIn className="text-4xl sm:text-5xl" />
+            </IconButton>
+            <IconButton
+              href="https://github.com/BentAllenDesign"
+              aria-label="Follow on GitHub"
+              className={clsx("transition-all duration-100 ease-in-out", darkMode ? 'text-slate-400 hover:text-slate-200' : 'text-slate-800 hover:text-slate-600')}
+            >
+              <GitHub className="text-4xl sm:text-5xl" />
+            </IconButton>
+            <Button endIcon={<ChevronRightRounded />} className={clsx("ml-3 normal-case rounded-full font-bold text-base sm:text-lg sm:my-1 px-4 sm:px-6", darkMode ? 'bg-slate-400 hover:bg-slate-200 text-slate-800' : 'bg-slate-800 hover:bg-slate-600 text-slate-100')}>
+              <Link to="/about" className="text-inherit no-underline">
+                Learn more<span className="hidden xs:inline"> about me</span>!
+              </Link>
+            </Button>
           </Box>
         </Box>
       </Container>
-      <Divider className={clsx("w-screen my-12", darkMode && "bg-slate-600")} />
+      <Divider className={clsx("w-screen mt-10 sm:mt-20 mb-8 sm:mb-12", darkMode && "bg-slate-600")} />
       <Container className="space-y-12">
         <Box className="flex flex-col md:flex-row-reverse w-full gap-8">
           <Box className="md:w-1/3">
-            <h2 className={clsx("font-display", darkMode ? 'text-slate-200' : 'text-slate-800')}>Work History</h2>
+            <h2 className={clsx("font-display mt-0 text-3xl lg:text-4xl", darkMode ? 'text-slate-200' : 'text-slate-800')}>Work History</h2>
             <Paper variant="outlined" className={clsx("p-8", darkMode && "bg-slate-800 border-slate-700")}>
               {my.jobs.map(({ Icon, ...job }, idx) => (
                 <Box key={idx} className={clsx("flex gap-x-2 mb-4 last:mb-0", darkMode ? 'text-slate-200' : 'text-slate-800')}>
@@ -71,7 +69,7 @@ export const LandingPage = (props: IPageProps) => {
             </Paper>
           </Box>
           <Box className="md:w-2/3">
-            <h2 className={clsx("font-display", darkMode ? 'text-slate-200' : 'text-slate-800')}>Projects</h2>
+            <h2 className={clsx("font-display md:mt-0 text-3xl lg:text-4xl", darkMode ? 'text-slate-200' : 'text-slate-800')}>Projects</h2>
             <Paper variant="outlined" className={clsx("p-8 flex items-center justify-center", darkMode && "bg-slate-800 border-slate-700")}>
               <span className="font-display text-4xl font-bold mt-2 animate-bounce text-slate-500">
                 Coming Soon!
@@ -81,5 +79,5 @@ export const LandingPage = (props: IPageProps) => {
         </Box>
       </Container>
     </>
-  )
+  );
 }

--- a/src/pages/ResumePage.tsx
+++ b/src/pages/ResumePage.tsx
@@ -6,7 +6,6 @@ import { useEffect } from 'react'
 import { Details, Header, HeartSeparatedList, Section } from '../components/Resume'
 import { useAppTheme } from '../lib/hooks/useAppTheme'
 import { IPageProps } from '../lib/types'
-import { BoltRounded } from '@mui/icons-material'
 
 export const ResumePage = (props: IPageProps) => {
   const theme = useAppTheme();

--- a/src/pages/ResumePage.tsx
+++ b/src/pages/ResumePage.tsx
@@ -6,6 +6,7 @@ import { useEffect } from 'react'
 import { Details, Header, HeartSeparatedList, Section } from '../components/Resume'
 import { useAppTheme } from '../lib/hooks/useAppTheme'
 import { IPageProps } from '../lib/types'
+import { BoltRounded } from '@mui/icons-material'
 
 export const ResumePage = (props: IPageProps) => {
   const theme = useAppTheme();
@@ -14,66 +15,66 @@ export const ResumePage = (props: IPageProps) => {
 
   return (
     <Container className={clsx("max-w-5xl", theme.darkMode ? 'text-slate-100' : 'text-slate-800')}>
-      <div className='resume'>
-        <Header {...theme} />
-        <Section title='Projects'>
-          <ul className='[&>*]:my-4'>
-            {my.projects.map(({ Icon, ...project }, idx) => (
-              <Box key={idx} className='flex gap-x-2'>
-                <Icon />
-                <Box>
-                  <b className='text-lg'>{project.name}: </b>
-                  <span className={clsx(theme.darkMode ? 'text-slate-300' : 'text-slate-700')}>{project.detail}</span>
-                </Box>
+      <Header {...theme} />
+      <Section title='Projects'>
+        <ul className='[&>*]:my-4'>
+          {my.projects.map(({ Icon, ...project }, idx) => (
+            <Box key={idx} className='flex gap-x-2'>
+              <Icon className="mt-0.5" />
+              <Box>
+                <b className='text-lg'>{project.name}: </b>
+                <span className={clsx(theme.darkMode ? 'text-slate-300' : 'text-slate-700')}>{project.detail}</span>
               </Box>
-            ))}
-          </ul>
-        </Section>
-        <Section title='Skills'>
-          <ul className='[&>*]:my-4'>
-            {Object.keys(my.skills).map((key, idx) => {
-              const Icon = my.skills[key].Icon;
-              return (
-                <Box key={idx} className='flex gap-x-2'>
-                  <Icon />
-                  <b className='text-lg'>{key.charAt(0).toUpperCase() + key.slice(1)}: </b>
+            </Box>
+          ))}
+        </ul>
+      </Section>
+      <Section title='Skills'>
+        <ul className='[&>*]:my-4'>
+          {Object.keys(my.skills).map((key, idx) => {
+            const Icon = my.skills[key].Icon;
+            return (
+              <Box key={idx} className='flex gap-x-2'>
+                <Icon className="mt-0.5" />
+                <Box>
+                  <b className="text-lg">{key.charAt(0).toUpperCase() + key.slice(1)}: </b>
                   {HeartSeparatedList(my.skills[key].bullets, theme.darkMode)}
                 </Box>
-              )
-            })}
+              </Box>
+            )
+          })}
+        </ul>
+      </Section>
+      <Section title='Experience'>
+        {my.jobs.map(({ Icon, ...job }, idx) => (
+          <ul key={idx}>
+            <Box className="flex gap-x-2">
+              <Icon className="mt-0.5" />
+              <Details {...job as IMyExperience} size="base" darkMode={theme.darkMode} />
+            </Box>
+            <ul className='-ml-2'>
+              {job.bullets.map((item, j) => (
+                <li key={j} className={clsx(theme.darkMode ? 'text-slate-300' : 'text-slate-700')}>{item}</li>
+              ))}
+            </ul>
           </ul>
-        </Section>
-        <Section title='Experience'>
-          {my.jobs.map(({ Icon, ...job }, idx) => (
-            <ul key={idx}>
-              <Box className="flex gap-x-2">
-                <Icon />
-                <Details {...job as IMyExperience} size="base" darkMode={theme.darkMode} />
-              </Box>
-              <ul>
-                {job.bullets.map((item, j) => (
-                  <li key={j} className={clsx(theme.darkMode ? 'text-slate-300' : 'text-slate-700')}>{item}</li>
-                ))}
-              </ul>
+        ))}
+      </Section>
+      <Section title='Education'>
+        {my.education.map(({ Icon, ...education }, idx) => (
+          <ul key={idx}>
+            <Box className="flex gap-x-2">
+              <Icon className="mt-0.5" />
+              <Details {...education as IMyExperience} size="base" darkMode={theme.darkMode} />
+            </Box>
+            <ul>
+              {education.bullets.map((bullet, j) => (
+                <li key={j}>{bullet}</li>
+              ))}
             </ul>
-          ))}
-        </Section>
-        <Section title='Education'>
-          {my.education.map(({ Icon, ...education }, idx) => (
-            <ul key={idx}>
-              <Box className="flex gap-x-2">
-                <Icon />
-                <Details {...education as IMyExperience} size="base" darkMode={theme.darkMode} />
-              </Box>
-              <ul>
-                {education.bullets.map((bullet, j) => (
-                  <li key={j}>{bullet}</li>
-                ))}
-              </ul>
-            </ul>
-          ))}
-        </Section>
-      </div>
-    </Container>
+          </ul>
+        ))}
+      </Section>
+    </Container >
   )
 };


### PR DESCRIPTION
This PR adds styles to the footer to keep it at the bottom even when the screen is larger than the available content.

I also fixed up some ugly styling in the resume page as show here:
![image](https://user-images.githubusercontent.com/64994378/218296159-c5b30eb2-17e8-4631-87d5-11b73a16ceee.png)

Additionally, I added some dynamic wording the the hero headline to make sure the style is consistent between multiple screen widths